### PR TITLE
Make darken filter go away when screen size is full

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -217,10 +217,6 @@ main {
   padding: 20px;
 }
 
-.darken {
-  filter: brightness(35%);
-}
-
 article {
   height: fit-content;
   background-color: white;
@@ -357,6 +353,10 @@ card p {
     grid-template-columns: 1fr 1fr;
   }
 
+  .darken {
+  filter: brightness(35%);
+  }
+
   article {
     max-width: 350px;
   }
@@ -420,6 +420,10 @@ card p {
     grid-template-columns: 1fr;
     grid-gap: 2% 2%;
     padding: 10px 5%;
+  }
+
+  .darken {
+  filter: brightness(35%);
   }
 
   article {


### PR DESCRIPTION
@ckoga @KVeitch this fixes the issue where the "main" section stays darkened, even if you make the screen larger and no longer have the nav bar at top with the hamburger menu. Now, it should go away when the screen gets larger. 